### PR TITLE
[NEW]: PCAP_FSN_ENABLED to signal its availability

### DIFF
--- a/scripts/create_pcap_dir
+++ b/scripts/create_pcap_dir
@@ -2,7 +2,8 @@
 
 set +x
 
-if [[ "$PCAP_GCS_FUSE" == true ]]; then
+if [[ "$PCAP_GCS_FUSE" == true && "${PCAP_FSN_ENABLED}" == true ]]; then
+    # only create the PCAP files directory in GCS if FUSE and FSN are both enabled
     while : ; do
         gcsfuse_ready=$(mount | grep --color=never "${PCAP_MNT} type fuse" | wc -l | tr -d '\n')
         [[ "${gcsfuse_ready}" == '1' ]] \
@@ -13,10 +14,8 @@ if [[ "$PCAP_GCS_FUSE" == true ]]; then
     done
 
     mount | grep --color=never "${PCAP_MNT} type fuse"
-else 
-    echo "{\"severity\":\"NOTICE\",\"message\":\"GCS FUSE is disabled\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}"
+    
+    exec mkdir -pv "${PCAP_DIR}"
 fi
 
-set -x
-
-mkdir -pv "${PCAP_DIR}"
+echo "{\"severity\":\"NOTICE\",\"message\":\"GCS export is disabled\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}"

--- a/scripts/init
+++ b/scripts/init
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-printenv
-tcpdump --version
-
 export MDS_URL='http://metadata.google.internal/computeMetadata/v1'
 export MDS_CURL="curl -s -H Metadata-Flavor:Google ${MDS_URL}"
 
@@ -34,6 +31,10 @@ PCAP_FILE="${PCAP_TMP}/part"
 GCS_DIR="${GOOGLE_CLOUD_PROJECT}/${PCAP_EXEC_ENV}/${K_SERVICE}/${GCP_REGION}/${K_REVISION}/${PCAP_DATE}/${INSTANCE_ID}"
 PCAP_DIR="${PCAP_MNT}/${GCS_DIR}"
 
+export PCAP_GCS_FUSE=${PCAP_GCS_FUSE:-true}
+export PCAP_TCPDUMP=${PCAP_TCPDUMP:-true}
+export PCAP_JSONDUMP=${PCAP_JSON:-false}
+
 echo "PCAP_DEBUG=${PCAP_DEBUG:-false}" >> ${ENV_FILE}
 echo "PCAP_SUPERVISOR_PORT=${PCAP_SUPERVISOR_PORT:-23456}" >> ${ENV_FILE}
 echo "PCAP_COMPAT=${PCAP_COMPAT:-false}" >> ${ENV_FILE}
@@ -51,7 +52,7 @@ echo "PCAP_MNT=${PCAP_MNT}" >> ${ENV_FILE}
 echo "PCAP_TMP=${PCAP_TMP}" >> ${ENV_FILE}
 echo "PCAP_FILE=${PCAP_FILE}" >> ${ENV_FILE}
 echo "PCAP_DIR=${PCAP_DIR}" >> ${ENV_FILE}
-echo "PCAP_GCS_FUSE=${PCAP_GCS_FUSE:-true}" >> ${ENV_FILE}
+echo "PCAP_GCS_FUSE=${PCAP_GCS_FUSE}" >> ${ENV_FILE}
 echo "PCAP_GCS_BUCKET=${PCAP_GCS_BUCKET}" >> ${ENV_FILE}
 echo "PCAP_GCS_DIR=${GCS_DIR}" >> ${ENV_FILE}
 echo "GCS_DIR=${GCS_DIR}" >> ${ENV_FILE}
@@ -64,8 +65,8 @@ echo "PCAP_TZ=${PCAP_TIMEZONE:-UTC}" >> ${ENV_FILE}
 echo "PCAP_TO=${PCAP_TIMEOUT_SECS:-0}" >> ${ENV_FILE}
 echo "PCAP_ORDERED=${PCAP_ORDERED:-false}" >> ${ENV_FILE}
 echo "PCAP_CONNTRACK=${PCAP_CONNTRACK:-false}" >> ${ENV_FILE}
-echo "PCAP_TCPDUMP=${PCAP_TCPDUMP:-true}" >> ${ENV_FILE}
-echo "PCAP_JSONDUMP=${PCAP_JSON:-false}" >> ${ENV_FILE}
+echo "PCAP_TCPDUMP=${PCAP_TCPDUMP}" >> ${ENV_FILE}
+echo "PCAP_JSONDUMP=${PCAP_JSONDUMP}" >> ${ENV_FILE}
 echo "PCAP_JSONDUMP_LOG=${PCAP_JSON_LOG:-false}" >> ${ENV_FILE}
 
 # short-rotate-secs == small-pcap-files
@@ -92,6 +93,12 @@ echo "PCAP_PORTS=${PCAP_PORTS:-ALL}" >> ${ENV_FILE}
 # simple filter; comma separated list of lowercase TCP flags that a segment must contain to be captured
 echo "PCAP_TCP_FLAGS=${PCAP_TCP_FLAGS:-ALL}" >> ${ENV_FILE}
 
+if [[ "${PCAP_TCPDUMP}" == true || "${PCAP_JSONDUMP}" == true ]]; then
+  echo "PCAP_FSN_ENABLED=true" >> ${ENV_FILE}
+else
+  echo "PCAP_FSN_ENABLED=false" >> ${ENV_FILE}
+fi
+
 # Create both paths to store PCAP files
 mkdir -pv ${PCAP_MNT}
 mkdir -pv ${PCAP_TMP}
@@ -100,7 +107,10 @@ if [[ "$PCAP_GCS_FUSE" == true ]]; then
   echo "{\"severity\":\"NOTICE\",\"message\":\"PCAP files will be available at: gs://${PCAP_GCS_BUCKET}/${GCS_DIR}\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"init\"}"
 fi
 
-cat -n ${ENV_FILE}
+if [[ "${PCAP_DEBUG}" == true ]]; then
+  tcpdump --version
+  cat -n ${ENV_FILE}
+fi
 
 trap 'kill -TERM $PCAP_PID' TERM INT
 /bin/supervisord --configuration=/pcap.conf --env-file=${ENV_FILE} &

--- a/scripts/start_pcapfsn
+++ b/scripts/start_pcapfsn
@@ -2,6 +2,11 @@
 
 set +x
 
+if [[ "${PCAP_FSN_ENABLED}" == false ]]; then
+    echo "{\"severity\":\"NOTICE\",\"message\":\"not exporting PCAP files to GCS\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}"
+    exec sleep infinity
+fi
+
 while : ; do
     [[ -d ${PCAP_DIR} ]] \
         && echo "{\"severity\":\"INFO\",\"message\":\"PCAP files directory is now available at: ${PCAP_DIR}\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}" \
@@ -19,29 +24,25 @@ if [[ "${PCAP_RT_ENV}" == "cloud_run_gen1" ]]; then
     export PCAP_COMPAT='true'
 fi
 
-
-if [[ "${PCAP_TCPDUMP}" == true || "${PCAP_JSONDUMP}" == true ]]; then
-    set -x
-
+if [[ "${PCAP_DEBUG}" == false ]]; then
     ls -l "${PCAP_DIR}"
-
-    # `exec` allows `/bin/pcap_fsn` to receive signals directly
-    exec env /bin/pcap_fsn \
-        -debug="${PCAP_DEBUG:-false}" \
-        -env="${PCAP_EXEC_ENV:-run}" \
-        -run=${PCAP_RUN:-true} \
-        -gae=${PCAP_GAE:-false} \
-        -gke=${PCAP_GKE:-false} \
-        -src_dir=${PCAP_TMP} \
-        -gcs_dir=${PCAP_DIR} \
-        -pcap_ext="${PCAP_EXT}" \
-        -gzip="${PCAP_GZIP:-true}" \
-        -interval="${PCAP_SECS:-60}" \
-        -retries_max="${PCAP_FSN_RETRIES_MAX:-6}" \
-        -retries_delay="${PCAP_FSN_RETRIES_DELAY:-2}" \
-        -compat="${PCAP_COMPAT:-false}" \
-        -rt_env="${PCAP_RT_ENV:-cloud_run_gen2}"
-else
-    echo "{\"severity\":\"NOTICE\",\"message\":\"not exporting PCAP files to GCS\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}"
-    exec sleep infinity
 fi
+
+set -x
+
+# `exec` allows `/bin/pcap_fsn` to receive signals directly
+exec env /bin/pcap_fsn \
+    -debug="${PCAP_DEBUG:-false}" \
+    -env="${PCAP_EXEC_ENV:-run}" \
+    -run=${PCAP_RUN:-true} \
+    -gae=${PCAP_GAE:-false} \
+    -gke=${PCAP_GKE:-false} \
+    -src_dir=${PCAP_TMP} \
+    -gcs_dir=${PCAP_DIR} \
+    -pcap_ext="${PCAP_EXT}" \
+    -gzip="${PCAP_GZIP:-true}" \
+    -interval="${PCAP_SECS:-60}" \
+    -retries_max="${PCAP_FSN_RETRIES_MAX:-6}" \
+    -retries_delay="${PCAP_FSN_RETRIES_DELAY:-2}" \
+    -compat="${PCAP_COMPAT:-false}" \
+    -rt_env="${PCAP_RT_ENV:-cloud_run_gen2}"

--- a/scripts/start_tcpdumpw
+++ b/scripts/start_tcpdumpw
@@ -2,14 +2,17 @@
 
 set +x
 
-while : ; do
-    pcapfsn_ready=$(ps -efa | grep --color=never '/pcap_fsn' | grep --color=never -v grep | wc -l  | tr -d '\n')
-    [[ "${pcapfsn_ready}" == '1' ]] \
-        && echo "{\"severity\":\"INFO\",\"message\":\"PCAP FS notifier is running\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}" \
-        && break
-    echo "{\"severity\":\"WARNING\",\"message\":\"Waiting for PCAP FS notifier to run ...\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}"
-    sleep 1
-done
+if [[ "${PCAP_FSN_ENABLED}" == true ]]; then
+    # only wait for PCAP FSN if it is enabled
+    while : ; do
+        pcapfsn_ready=$(ps -efa | grep --color=never '/pcap_fsn' | grep --color=never -v grep | wc -l  | tr -d '\n')
+        [[ "${pcapfsn_ready}" == '1' ]] \
+            && echo "{\"severity\":\"INFO\",\"message\":\"PCAP FS notifier is running\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}" \
+            && break
+        echo "{\"severity\":\"WARNING\",\"message\":\"Waiting for PCAP FS notifier to run ...\",\"sidecar\":\"${APP_SIDECAR}\",\"module\":\"${PROC_NAME}\"}"
+        sleep 1
+    done
+fi
 
 EPHEMERAL_PORT_RANGE=`cat /proc/sys/net/ipv4/ip_local_port_range | tr '\t' ' ' | tr -s ' ' | tr ' ' ',' | tr -d '\n'`
 
@@ -22,8 +25,10 @@ if [[ "${PCAP_RT_ENV}" == "cloud_run_gen1" ]]; then
     export PCAP_COMPAT='true'
 fi
 
-ls -l /bin/tcpdump
-ls -l /bin/tcpdumpw
+if [[ "${PCAP_DEBUG}" == true ]]; then
+    ls -l /bin/tcpdump
+    ls -l /bin/tcpdumpw
+fi
 
 set -x
 


### PR DESCRIPTION
This change simplifies how PCAP sidecar's processes detect if file exports to GCS are enabled.

In particular, file exports to GCS are only enabled if any of `tcpdump` or `jsondump` are enabled;
in such case, `pcap_fsn` will take care of moving files into GCS.

If neither of `tcpdump` or `jsondump` are enabled, there's no point in even starting `pcap_fsn`;
which means that `tcpdumpw` must not have it as a dependency in such scenarios.